### PR TITLE
set variables from a single file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Prerequisite
 
 1. RVV Compiler
-   1. Set `gcc` and `objdump` variables in two files: `scripts/run_riscof_coverage.py` and `scripts/run_spike.py`
+   1. Set `gcc`,`objdump`, and `riscof` directory's path variables in file: `scripts/constants.py`
 2. RISCV-ISAC RVV Support
    1. `git clone https://github.com/hushenwei2000/riscv-isac-rvv`
    2. `cd riscv-isac-rvv`

--- a/run.py
+++ b/run.py
@@ -1,4 +1,3 @@
-
 import argparse
 from ast import arg
 import os
@@ -7,6 +6,7 @@ from scripts.lib import *
 from scripts.replace_results import replace_results
 from scripts.run_riscof_coverage import run_riscof_coverage
 from scripts.run_spike import run_spike
+from scripts.constants import *
 
 
 def parse_args(cwd):
@@ -141,7 +141,7 @@ def run_mask(cwd, args, cgf, output_dir):
     empty_test = create_empty_test(
         args.i, args.xlen, args.vlen, args.vsew, args.lmul, args.vta, args.vma, output_dir)
 
-    riscof_dir = '/work/stu/swhu/projects/riscof-sample'
+    riscof_dir = RISCOF_CONST
 
     if args.tool == 'sail':
         # 2-1. Run sail and riscof coverage and extract true result from isac_log

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -1,0 +1,5 @@
+RISCOF_CONST = '/work/stu/swhu/projects/riscof-sample'
+
+GCC_CONST = 'riscv64-rivai-elf-gcc'
+
+OBJDUMP_CONST = 'riscv64-rivai-elf-objdump'

--- a/scripts/run_riscof_coverage.py
+++ b/scripts/run_riscof_coverage.py
@@ -1,10 +1,11 @@
 import logging
 import os
 
+from scripts.constants import *
 
 def run_riscof_coverage(instr, rvv_atg_root, cgf_path, output_dir, test_path, suffix, xlen, flen, vlen, elen, vsew, lmul, use_fail_macro, tool):
-    gcc = "riscv64-rivai-elf-gcc"
-    objdump = "riscv64-rivai-elf-objdump"
+    gcc = GCC_CONST
+    objdump = OBJDUMP_CONST
     logging.info("Running riscof coverage: {}.{}".format(instr, suffix))
     test_path = os.path.basename(test_path)
     # cgf_path = os.path.basename(cgf_path)

--- a/scripts/run_spike.py
+++ b/scripts/run_spike.py
@@ -1,10 +1,11 @@
 import logging
 import os
 
+from scripts.constants import *
 
 def run_spike(instr, rvv_atg_root, cgf_path, output_dir, test_path, suffix, xlen, flen, vlen, elen, vsew, lmul, use_fail_macro):
-    gcc = "riscv64-rivai-elf-gcc"
-    objdump = "riscv64-rivai-elf-objdump"
+    gcc = GCC_CONST
+    objdump = OBJDUMP_CONST
     logging.info("Running spike: {}.{}".format(instr, suffix))
     test_path = os.path.basename(test_path)
     cgf_path = os.path.basename(cgf_path)


### PR DESCRIPTION
Setting path variables from a single file will save a lot of time for new users. Also, it's preferable if dependencies are built from repositories and not using `pip install *` etc.