### PR TITLE
fix: regs when lmul set to 2/4/8

### DIFF
--- a/cgfs/l/lmul2/vle16.yaml
+++ b/cgfs/l/lmul2/vle16.yaml
@@ -7,7 +7,7 @@ vle16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_quard_regs
     val_comb:
         'ea_align == 0': 0
         'ea_align == 2': 0

--- a/cgfs/l/lmul2/vle32.yaml
+++ b/cgfs/l/lmul2/vle32.yaml
@@ -7,7 +7,7 @@ vle32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/lmul2/vle64.yaml
+++ b/cgfs/l/lmul2/vle64.yaml
@@ -7,7 +7,7 @@ vle64:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/lmul2/vlre16.yaml
+++ b/cgfs/l/lmul2/vlre16.yaml
@@ -9,7 +9,7 @@ vlre16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_quard_regs
     val_comb:
         'ea_align == 0': 0
         'ea_align == 2': 0

--- a/cgfs/l/lmul2/vlre32.yaml
+++ b/cgfs/l/lmul2/vlre32.yaml
@@ -9,7 +9,7 @@ vlre32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/lmul2/vlse16.yaml
+++ b/cgfs/l/lmul2/vlse16.yaml
@@ -6,7 +6,7 @@ vlse16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_quard_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/lmul2/vlse32.yaml
+++ b/cgfs/l/lmul2/vlse32.yaml
@@ -6,7 +6,7 @@ vlse32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/lmul2/vlse64.yaml
+++ b/cgfs/l/lmul2/vlse64.yaml
@@ -6,7 +6,7 @@ vlse64:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/lmul2/vlsege16.yaml
+++ b/cgfs/l/lmul2/vlsege16.yaml
@@ -11,7 +11,7 @@ vlsege16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_quard_regs
     val_comb:
         'ea_align == 0': 0
         'ea_align == 2': 0

--- a/cgfs/l/lmul2/vlsege32.yaml
+++ b/cgfs/l/lmul2/vlsege32.yaml
@@ -11,7 +11,7 @@ vlsege32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/lmul2/vlssege16.yaml
+++ b/cgfs/l/lmul2/vlssege16.yaml
@@ -12,7 +12,7 @@ vlssege16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_quard_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/lmul2/vlssege32.yaml
+++ b/cgfs/l/lmul2/vlssege32.yaml
@@ -12,7 +12,7 @@ vlssege32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/lmul2/vluxei16.yaml
+++ b/cgfs/l/lmul2/vluxei16.yaml
@@ -6,7 +6,7 @@ vluxei16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_quard_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 16)': 0

--- a/cgfs/l/lmul2/vluxei32.yaml
+++ b/cgfs/l/lmul2/vluxei32.yaml
@@ -6,7 +6,7 @@ vluxei32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 32)': 0

--- a/cgfs/l/lmul2/vluxei64.yaml
+++ b/cgfs/l/lmul2/vluxei64.yaml
@@ -6,7 +6,7 @@ vluxei64:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 64)': 0

--- a/cgfs/l/lmul2/vluxsegei16.yaml
+++ b/cgfs/l/lmul2/vluxsegei16.yaml
@@ -12,7 +12,7 @@ vluxsegei16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_quard_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 16)': 0

--- a/cgfs/l/lmul2/vluxsegei32.yaml
+++ b/cgfs/l/lmul2/vluxsegei32.yaml
@@ -12,7 +12,7 @@ vluxsegei32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 32)': 0

--- a/cgfs/l/lmul2/vs2r.yaml
+++ b/cgfs/l/lmul2/vs2r.yaml
@@ -6,7 +6,7 @@ vs2r:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_quard_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/lmul2/vs4r.yaml
+++ b/cgfs/l/lmul2/vs4r.yaml
@@ -6,7 +6,7 @@ vs4r:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/lmul2/vs8r.yaml
+++ b/cgfs/l/lmul2/vs8r.yaml
@@ -6,7 +6,7 @@ vs8r:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/lmul2/vse16.yaml
+++ b/cgfs/l/lmul2/vse16.yaml
@@ -6,7 +6,7 @@ vse16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_quard_regs
     val_comb:
         'ea_align == 0': 0
         'ea_align == 2': 0

--- a/cgfs/l/lmul2/vse32.yaml
+++ b/cgfs/l/lmul2/vse32.yaml
@@ -6,7 +6,7 @@ vse32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/lmul2/vsse16.yaml
+++ b/cgfs/l/lmul2/vsse16.yaml
@@ -6,7 +6,7 @@ vsse16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_quard_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/lmul2/vsse32.yaml
+++ b/cgfs/l/lmul2/vsse32.yaml
@@ -6,7 +6,7 @@ vsse32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/lmul2/vssege16.yaml
+++ b/cgfs/l/lmul2/vssege16.yaml
@@ -11,7 +11,7 @@ vssege16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_quard_regs
     val_comb:
         'ea_align == 0': 0
         'ea_align == 2': 0

--- a/cgfs/l/lmul2/vssege32.yaml
+++ b/cgfs/l/lmul2/vssege32.yaml
@@ -11,7 +11,7 @@ vssege32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/lmul2/vsssege16.yaml
+++ b/cgfs/l/lmul2/vsssege16.yaml
@@ -12,7 +12,7 @@ vsssege16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_quard_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/lmul2/vsssege32.yaml
+++ b/cgfs/l/lmul2/vsssege32.yaml
@@ -12,7 +12,7 @@ vsssege32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/lmul2/vsuxei16.yaml
+++ b/cgfs/l/lmul2/vsuxei16.yaml
@@ -6,7 +6,7 @@ vsuxei16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_quard_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 16)': 0

--- a/cgfs/l/lmul2/vsuxei32.yaml
+++ b/cgfs/l/lmul2/vsuxei32.yaml
@@ -6,7 +6,7 @@ vsuxei32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 32)': 0

--- a/cgfs/l/lmul2/vsuxsegei16.yaml
+++ b/cgfs/l/lmul2/vsuxsegei16.yaml
@@ -12,7 +12,7 @@ vsuxsegei16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_quard_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 16)': 0

--- a/cgfs/l/lmul2/vsuxsegei32.yaml
+++ b/cgfs/l/lmul2/vsuxsegei32.yaml
@@ -12,7 +12,7 @@ vsuxsegei32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 16)': 0

--- a/cgfs/l/lmul4/vle16.yaml
+++ b/cgfs/l/lmul4/vle16.yaml
@@ -7,7 +7,7 @@ vle16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'ea_align == 2': 0

--- a/cgfs/l/lmul4/vle32.yaml
+++ b/cgfs/l/lmul4/vle32.yaml
@@ -7,7 +7,7 @@ vle32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/lmul4/vle64.yaml
+++ b/cgfs/l/lmul4/vle64.yaml
@@ -7,7 +7,7 @@ vle64:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/lmul4/vlre16.yaml
+++ b/cgfs/l/lmul4/vlre16.yaml
@@ -9,7 +9,7 @@ vlre16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'ea_align == 2': 0

--- a/cgfs/l/lmul4/vlre32.yaml
+++ b/cgfs/l/lmul4/vlre32.yaml
@@ -9,7 +9,7 @@ vlre32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/lmul4/vlse16.yaml
+++ b/cgfs/l/lmul4/vlse16.yaml
@@ -6,7 +6,7 @@ vlse16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/lmul4/vlse32.yaml
+++ b/cgfs/l/lmul4/vlse32.yaml
@@ -6,7 +6,7 @@ vlse32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/lmul4/vlse64.yaml
+++ b/cgfs/l/lmul4/vlse64.yaml
@@ -6,7 +6,7 @@ vlse64:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/lmul4/vlsege16.yaml
+++ b/cgfs/l/lmul4/vlsege16.yaml
@@ -11,7 +11,7 @@ vlsege16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'ea_align == 2': 0

--- a/cgfs/l/lmul4/vlsege32.yaml
+++ b/cgfs/l/lmul4/vlsege32.yaml
@@ -11,7 +11,7 @@ vlsege32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/lmul4/vlssege16.yaml
+++ b/cgfs/l/lmul4/vlssege16.yaml
@@ -12,7 +12,7 @@ vlssege16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/lmul4/vlssege32.yaml
+++ b/cgfs/l/lmul4/vlssege32.yaml
@@ -12,7 +12,7 @@ vlssege32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/lmul4/vluxei16.yaml
+++ b/cgfs/l/lmul4/vluxei16.yaml
@@ -6,7 +6,7 @@ vluxei16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 16)': 0

--- a/cgfs/l/lmul4/vluxei32.yaml
+++ b/cgfs/l/lmul4/vluxei32.yaml
@@ -6,7 +6,7 @@ vluxei32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 32)': 0

--- a/cgfs/l/lmul4/vluxei64.yaml
+++ b/cgfs/l/lmul4/vluxei64.yaml
@@ -6,7 +6,7 @@ vluxei64:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 64)': 0

--- a/cgfs/l/lmul4/vluxsegei16.yaml
+++ b/cgfs/l/lmul4/vluxsegei16.yaml
@@ -12,7 +12,7 @@ vluxsegei16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 16)': 0

--- a/cgfs/l/lmul4/vluxsegei32.yaml
+++ b/cgfs/l/lmul4/vluxsegei32.yaml
@@ -12,7 +12,7 @@ vluxsegei32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 32)': 0

--- a/cgfs/l/lmul4/vs2r.yaml
+++ b/cgfs/l/lmul4/vs2r.yaml
@@ -6,7 +6,7 @@ vs2r:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/lmul4/vs4r.yaml
+++ b/cgfs/l/lmul4/vs4r.yaml
@@ -6,7 +6,7 @@ vs4r:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/lmul4/vs8r.yaml
+++ b/cgfs/l/lmul4/vs8r.yaml
@@ -6,7 +6,7 @@ vs8r:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/lmul4/vse16.yaml
+++ b/cgfs/l/lmul4/vse16.yaml
@@ -6,7 +6,7 @@ vse16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'ea_align == 2': 0

--- a/cgfs/l/lmul4/vse32.yaml
+++ b/cgfs/l/lmul4/vse32.yaml
@@ -6,7 +6,7 @@ vse32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/lmul4/vsse16.yaml
+++ b/cgfs/l/lmul4/vsse16.yaml
@@ -6,7 +6,7 @@ vsse16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/lmul4/vsse32.yaml
+++ b/cgfs/l/lmul4/vsse32.yaml
@@ -6,7 +6,7 @@ vsse32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/lmul4/vssege16.yaml
+++ b/cgfs/l/lmul4/vssege16.yaml
@@ -11,7 +11,7 @@ vssege16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'ea_align == 2': 0

--- a/cgfs/l/lmul4/vssege32.yaml
+++ b/cgfs/l/lmul4/vssege32.yaml
@@ -11,7 +11,7 @@ vssege32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/lmul4/vsssege16.yaml
+++ b/cgfs/l/lmul4/vsssege16.yaml
@@ -12,7 +12,7 @@ vsssege16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/lmul4/vsssege32.yaml
+++ b/cgfs/l/lmul4/vsssege32.yaml
@@ -12,7 +12,7 @@ vsssege32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/lmul4/vsuxei16.yaml
+++ b/cgfs/l/lmul4/vsuxei16.yaml
@@ -6,7 +6,7 @@ vsuxei16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 16)': 0

--- a/cgfs/l/lmul4/vsuxei32.yaml
+++ b/cgfs/l/lmul4/vsuxei32.yaml
@@ -6,7 +6,7 @@ vsuxei32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 32)': 0

--- a/cgfs/l/lmul4/vsuxsegei16.yaml
+++ b/cgfs/l/lmul4/vsuxsegei16.yaml
@@ -12,7 +12,7 @@ vsuxsegei16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 16)': 0

--- a/cgfs/l/lmul4/vsuxsegei32.yaml
+++ b/cgfs/l/lmul4/vsuxsegei32.yaml
@@ -12,7 +12,7 @@ vsuxsegei32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_quard_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 16)': 0

--- a/cgfs/l/lmul8/vs2r.yaml
+++ b/cgfs/l/lmul8/vs2r.yaml
@@ -6,7 +6,7 @@ vs2r:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/lmul8/vs4r.yaml
+++ b/cgfs/l/lmul8/vs4r.yaml
@@ -6,7 +6,7 @@ vs4r:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/lmul8/vs8r.yaml
+++ b/cgfs/l/lmul8/vs8r.yaml
@@ -6,7 +6,7 @@ vs8r:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/vle16.yaml
+++ b/cgfs/l/vle16.yaml
@@ -7,7 +7,7 @@ vle16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_even_regs
     val_comb:
         'ea_align == 0': 0
         'ea_align == 2': 0

--- a/cgfs/l/vle32.yaml
+++ b/cgfs/l/vle32.yaml
@@ -7,7 +7,7 @@ vle32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_quard_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/vle64.yaml
+++ b/cgfs/l/vle64.yaml
@@ -7,7 +7,7 @@ vle64:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/vlre16.yaml
+++ b/cgfs/l/vlre16.yaml
@@ -9,7 +9,7 @@ vlre16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_even_regs
     val_comb:
         'ea_align == 0': 0
         'ea_align == 2': 0

--- a/cgfs/l/vlre32.yaml
+++ b/cgfs/l/vlre32.yaml
@@ -9,7 +9,7 @@ vlre32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_quard_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/vlse16.yaml
+++ b/cgfs/l/vlse16.yaml
@@ -6,7 +6,7 @@ vlse16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_even_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/vlse32.yaml
+++ b/cgfs/l/vlse32.yaml
@@ -6,7 +6,7 @@ vlse32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_quard_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/vlse64.yaml
+++ b/cgfs/l/vlse64.yaml
@@ -6,7 +6,7 @@ vlse64:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_octant_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/vlsege16.yaml
+++ b/cgfs/l/vlsege16.yaml
@@ -11,7 +11,7 @@ vlsege16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_even_regs
     val_comb:
         'ea_align == 0': 0
         'ea_align == 2': 0

--- a/cgfs/l/vlsege32.yaml
+++ b/cgfs/l/vlsege32.yaml
@@ -11,7 +11,7 @@ vlsege32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_quard_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/vlssege16.yaml
+++ b/cgfs/l/vlssege16.yaml
@@ -12,7 +12,7 @@ vlssege16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_even_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/vlssege32.yaml
+++ b/cgfs/l/vlssege32.yaml
@@ -12,7 +12,7 @@ vlssege32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_quard_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/vluxei16.yaml
+++ b/cgfs/l/vluxei16.yaml
@@ -6,7 +6,7 @@ vluxei16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_even_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 16)': 0

--- a/cgfs/l/vluxei32.yaml
+++ b/cgfs/l/vluxei32.yaml
@@ -6,7 +6,7 @@ vluxei32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_quard_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 32)': 0

--- a/cgfs/l/vluxei64.yaml
+++ b/cgfs/l/vluxei64.yaml
@@ -6,7 +6,7 @@ vluxei64:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 64)': 0

--- a/cgfs/l/vluxsegei16.yaml
+++ b/cgfs/l/vluxsegei16.yaml
@@ -12,7 +12,7 @@ vluxsegei16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_even_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 16)': 0

--- a/cgfs/l/vluxsegei32.yaml
+++ b/cgfs/l/vluxsegei32.yaml
@@ -12,7 +12,7 @@ vluxsegei32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_quard_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 32)': 0

--- a/cgfs/l/vs4r.yaml
+++ b/cgfs/l/vs4r.yaml
@@ -6,7 +6,7 @@ vs4r:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_quard_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/vs8r.yaml
+++ b/cgfs/l/vs8r.yaml
@@ -6,7 +6,7 @@ vs8r:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_even_regs
+      <<: *v_octant_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/vse16.yaml
+++ b/cgfs/l/vse16.yaml
@@ -6,7 +6,7 @@ vse16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_even_regs
     val_comb:
         'ea_align == 0': 0
         'ea_align == 2': 0

--- a/cgfs/l/vse32.yaml
+++ b/cgfs/l/vse32.yaml
@@ -6,7 +6,7 @@ vse32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_quard_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/vsse16.yaml
+++ b/cgfs/l/vsse16.yaml
@@ -6,7 +6,7 @@ vsse16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_even_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/vsse32.yaml
+++ b/cgfs/l/vsse32.yaml
@@ -6,7 +6,7 @@ vsse32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_quard_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/vssege16.yaml
+++ b/cgfs/l/vssege16.yaml
@@ -11,7 +11,7 @@ vssege16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_even_regs
     val_comb:
         'ea_align == 0': 0
         'ea_align == 2': 0

--- a/cgfs/l/vssege32.yaml
+++ b/cgfs/l/vssege32.yaml
@@ -11,7 +11,7 @@ vssege32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_quard_regs
     val_comb:
         'ea_align == 0': 0
         'imm_val == 0': 0

--- a/cgfs/l/vsssege16.yaml
+++ b/cgfs/l/vsssege16.yaml
@@ -12,7 +12,7 @@ vsssege16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_even_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/vsssege32.yaml
+++ b/cgfs/l/vsssege32.yaml
@@ -12,7 +12,7 @@ vsssege32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_quard_regs
     val_comb:
         'imm_val > 0': 0
         'imm_val < 0': 0

--- a/cgfs/l/vsuxei16.yaml
+++ b/cgfs/l/vsuxei16.yaml
@@ -6,7 +6,7 @@ vsuxei16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_even_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 16)': 0

--- a/cgfs/l/vsuxei32.yaml
+++ b/cgfs/l/vsuxei32.yaml
@@ -6,7 +6,7 @@ vsuxei32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_quard_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 32)': 0

--- a/cgfs/l/vsuxsegei16.yaml
+++ b/cgfs/l/vsuxsegei16.yaml
@@ -12,7 +12,7 @@ vsuxsegei16:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_even_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 16)': 0

--- a/cgfs/l/vsuxsegei32.yaml
+++ b/cgfs/l/vsuxsegei32.yaml
@@ -12,7 +12,7 @@ vsuxsegei32:
     rs1: 
       <<: *all_regs_cropped
     rd: 
-      <<: *v_regs
+      <<: *v_quard_regs
     val_comb:
         'ea_align == 0': 0
         'walking_ones("imm_val", 16)': 0


### PR DESCRIPTION
Add YAML when lmul is set to 8.0 & fix the reg coverage when instruction width increase, like vle8 to vle16, the coverage will be set as vle8 when lmul=2.0.